### PR TITLE
Fix uuid for newer versions

### DIFF
--- a/lib/yookassa.js
+++ b/lib/yookassa.js
@@ -1,5 +1,5 @@
 const request = require('request');
-const uuid = require('uuid/v4');
+const uuid = require('uuid').v4;
 
 const Payment = require('./payment');
 const Refund = require('./refund');


### PR DESCRIPTION
Пакет uuid теперь имеет другую структуру, что выдает ошибку в проектах, использующих новые версии
```
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './v4' is not defined by "exports" in path\to\project\node_modules\uuid\package.json
```

Изменение, предложенное в MR, не сломает совместимость старых версий, но исправит поведение в новых